### PR TITLE
Add a Rails::Engine to support autoloading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,39 @@
 
 Server-side common library for Percy.
 
-## Percy::KeywordStruct
+## Installation
+
+Add this line to your application's Gemfile:
+
+```
+gem 'percy-common'
+```
+
+Or, for a Ruby library, add this to your gemspec:
+
+```ruby
+spec.add_development_dependency 'percy-common'
+```
+
+And then run:
+
+```bash
+$ bundle install
+```
+
+### Setup in a Rails app
+
+If including in a Rails app, add the following to your `application.rb`:
+
+```ruby
+require 'percy/common/engine'
+```
+
+This enables Rails to autoload the constants from this library without more `require` lines.
+
+## Usage
+
+### Percy::KeywordStruct
 
 A simple struct that can be used when you need to return a simple value object.
 
@@ -19,7 +51,7 @@ foo.qux  # --> nil
 foo.fake # --> raises NoMethodError
 ```
 
-## Percy.logger
+### Percy.logger
 
 ```ruby
 require 'percy/logger'
@@ -32,9 +64,9 @@ Percy.logger.error { 'error message' }
 
 Prefer the block form usage `Percy.logger.debug { 'message' }` over `Percy.logger.debug('message')` because it is slightly more efficient when the log will be excluded by the current logging level. For example, if the log level is currently `info`, then a `debug` log in block form will never evaluate or allocate the message string itself.
 
-## Percy::ProcessHelpers
+### Percy::ProcessHelpers
 
-### `gracefully_kill(pid[, grace_period_seconds: 10])`
+#### `gracefully_kill(pid[, grace_period_seconds: 10])`
 
 Returns `true` if the process was successfully killed, or `false` if the process did not exist or its exit status was already collected.
 
@@ -46,7 +78,7 @@ Percy::ProcessHelpers.gracefully_kill(pid)
 
 This will send `SIGTERM` to the process, wait up to 10 seconds, then send `SIGKILL` if it has not already shut down.
 
-## Percy::Stats
+### Percy::Stats
 
 Client for recording Datadog metrics and automatically setting up Percy-specific environment tags.
 

--- a/lib/percy/common/engine.rb
+++ b/lib/percy/common/engine.rb
@@ -1,0 +1,7 @@
+module Percy
+  module Common
+    class Engine < ::Rails::Engine
+      config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    end
+  end
+end


### PR DESCRIPTION
@djones turns out that as you predicted, things didn't autoload in Rails the way I thought they would. Have added support for that here.

- Following the approach from [here](https://content.pivotal.io/blog/rails-autoloading-for-your-gem), use a Rails::Engine to support autoloading constants from this gem in a Rails app. After this, we will add `require 'percy/common/engine'` to the Rails app `application.rb`, so constants from this library can be autoloaded in Rails without require.
- Improve docs.