### PR TITLE
Better picking of a random open port

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ inherit_gem:
 RSpec/DescribeClass:
   Exclude:
     - spec/percy/logger_spec.rb
+
+Style::ColonMethodCall:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,5 +6,5 @@ RSpec/DescribeClass:
   Exclude:
     - spec/percy/logger_spec.rb
 
-Style::ColonMethodCall:
+Style/ColonMethodCall:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,3 @@ inherit_gem:
 RSpec/DescribeClass:
   Exclude:
     - spec/percy/logger_spec.rb
-
-Style/ColonMethodCall:
-  Enabled: false

--- a/lib/percy/network_helpers.rb
+++ b/lib/percy/network_helpers.rb
@@ -4,16 +4,20 @@ require 'timeout'
 
 module Percy
   class NetworkHelpers
-    MIN_PORT = 1_024 # 0-1023 are system reserved
+    MIN_PORT = 1_024 # 0-1023 are not available without privilege
     MAX_PORT = 65_535 # (2^16) -1
+    MAX_PORT_ATTEMPTS = 50
 
     class ServerDown < RuntimeError; end
+    class OpenPortNotFound < RuntimeError; end
 
     def self.random_open_port
-      loop do
+      MAX_PORT_ATTEMPTS.times do
         port = rand(MIN_PORT..MAX_PORT)
         return port if port_open? port
       end
+
+      raise OpenPortNotFound
     end
 
     def self.port_open?(port, seconds = 1)

--- a/lib/percy/network_helpers.rb
+++ b/lib/percy/network_helpers.rb
@@ -1,6 +1,5 @@
 require 'socket'
 require 'excon'
-require 'timeout'
 
 module Percy
   class NetworkHelpers
@@ -20,17 +19,13 @@ module Percy
       raise OpenPortNotFound
     end
 
-    def self.port_open?(port, seconds = 1)
-      Timeout::timeout(seconds) do
-        begin
-          TCPServer.new(port).close
-          true
-        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRINUSE
-          false
-        end
+    def self.port_open?(port)
+      begin
+        TCPServer.new(port).close
+        true
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRINUSE
+        false
       end
-    rescue Timeout::Error
-      false
     end
 
     def self.verify_healthcheck(url:, expected_body: 'ok', retry_wait_seconds: 0.5)

--- a/lib/percy/network_helpers.rb
+++ b/lib/percy/network_helpers.rb
@@ -16,12 +16,12 @@ module Percy
       end
     end
 
-    def port_open?(port, seconds = 1)
+    def self.port_open?(port, seconds = 1)
       Timeout::timeout(seconds) do
         begin
           TCPServer.new(port).close
           true
-        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRINUSE
           false
         end
       end

--- a/spec/percy/network_helpers_spec.rb
+++ b/spec/percy/network_helpers_spec.rb
@@ -46,13 +46,6 @@ RSpec.describe Percy::NetworkHelpers do
       server.close
       expect(Percy::NetworkHelpers.port_open?(port)).to eq(true)
     end
-
-    it 'handles timeouts' do
-      expect(Percy::NetworkHelpers.port_open?(port)).to eq(true)
-
-      allow(TCPServer).to receive(:new).and_raise(Timeout::Error)
-      expect(Percy::NetworkHelpers.port_open?(port)).to eq(false)
-    end
   end
 
   describe '#verify_healthcheck' do

--- a/spec/percy/network_helpers_spec.rb
+++ b/spec/percy/network_helpers_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe Percy::NetworkHelpers do
       server.close
       expect(Percy::NetworkHelpers.port_open?(port)).to eq(true)
     end
+
+    it 'handles timeouts' do
+      expect(Percy::NetworkHelpers.port_open?(port)).to eq(true)
+
+      allow(TCPServer).to receive(:new).and_raise(Timeout::Error)
+      expect(Percy::NetworkHelpers.port_open?(port)).to eq(false)
+    end
   end
 
   describe '#verify_healthcheck' do

--- a/spec/percy/network_helpers_spec.rb
+++ b/spec/percy/network_helpers_spec.rb
@@ -21,10 +21,26 @@ RSpec.describe Percy::NetworkHelpers do
   end
 
   describe '#random_open_port' do
-    it 'returns a random open port' do
-      expect(Percy::NetworkHelpers.random_open_port).to be >= 1024
+    it 'returns a random open port in the desired range' do
+      expect(Percy::NetworkHelpers.random_open_port).to be >= described_class::MIN_PORT
+      expect(Percy::NetworkHelpers.random_open_port).to be <= described_class::MAX_PORT
     end
   end
+
+  describe '#port_open?' do
+    let(:port) { 7070 }
+
+    it 'tells you if a port is open or not' do
+      # Block the port and check it's not open
+      server = TCPServer.open port
+      expect(Percy::NetworkHelpers.port_open?(port)).to eq(false)
+
+      # Unblock the port and check it's open now
+      server.close
+      expect(Percy::NetworkHelpers.port_open?(port)).to eq(true)
+    end
+  end
+
   describe '#verify_healthcheck' do
     include_context 'has a test HTTP server'
 

--- a/spec/percy/network_helpers_spec.rb
+++ b/spec/percy/network_helpers_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Percy::NetworkHelpers do
       expect(Percy::NetworkHelpers.random_open_port).to be >= described_class::MIN_PORT
       expect(Percy::NetworkHelpers.random_open_port).to be <= described_class::MAX_PORT
     end
+
+    it 'raises an error when an open port is not found' do
+      allow(Percy::NetworkHelpers).to receive(:port_open?).and_return(false)
+
+      expect { Percy::NetworkHelpers.random_open_port }.to \
+        raise_error(Percy::NetworkHelpers::OpenPortNotFound)
+    end
   end
 
   describe '#port_open?' do


### PR DESCRIPTION
Asking the kernel for an open a port by connecting to `127.0.0.1:0` is fairly common, but it turns out that this will give you the same port back about 1% of the time, which can create some tricky race conditions.

In this approach, we instead look at the entire available port range, pick one at random and check it's it's available.

If it isn't available, simply pick another one. This approach also gracefully times out should a service respond on that port and remain open.