### PR TITLE
Upgrade dogstatsd-ruby and handle configurable host/port.

### DIFF
--- a/lib/percy/stats.rb
+++ b/lib/percy/stats.rb
@@ -1,11 +1,14 @@
-require 'statsd'
+require 'datadog/statsd'
 require 'time'
 
 module Percy
-  class Stats < ::Statsd
-    def initialize(*args)
-      super
-      self.tags = ["env:#{ENV['PERCY_ENV'] || 'development'}"]
+  class Stats < ::Datadog::Statsd
+    def initialize(host = nil, port = nil, opts = {}, max_buffer_size = 50)
+      host = ENV.fetch('DATADOG_AGENT_HOST', ::Datadog::Statsd::DEFAULT_HOST)
+      port = Integer(ENV.fetch('DATADOG_AGENT_PORT', ::Datadog::Statsd::DEFAULT_PORT))
+      opts[:tags] ||= []
+      opts[:tags] << "env:#{ENV['PERCY_ENV'] || 'development'}"
+      super(host, port, opts, max_buffer_size)
     end
 
     # Equivalent to stats.time, but without wrapping in blocks and dealing with var scoping issues.

--- a/lib/percy/stats.rb
+++ b/lib/percy/stats.rb
@@ -4,8 +4,8 @@ require 'time'
 module Percy
   class Stats < ::Datadog::Statsd
     def initialize(host = nil, port = nil, opts = {}, max_buffer_size = 50)
-      host = ENV.fetch('DATADOG_AGENT_HOST', ::Datadog::Statsd::DEFAULT_HOST)
-      port = Integer(ENV.fetch('DATADOG_AGENT_PORT', ::Datadog::Statsd::DEFAULT_PORT))
+      host ||= ENV.fetch('DATADOG_AGENT_HOST', ::Datadog::Statsd::DEFAULT_HOST)
+      port ||= Integer(ENV.fetch('DATADOG_AGENT_PORT', ::Datadog::Statsd::DEFAULT_PORT))
       opts[:tags] ||= []
       opts[:tags] << "env:#{ENV['PERCY_ENV'] || 'development'}"
       super(host, port, opts, max_buffer_size)

--- a/percy-common.gemspec
+++ b/percy-common.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'dogstatsd-ruby', '~> 1.6'
+  spec.add_dependency 'dogstatsd-ruby', '~> 3.1'
   spec.add_dependency 'syslog-logger', '~> 1.6'
   spec.add_dependency 'excon', '~> 0.57'
 

--- a/spec/percy/network_helpers_spec.rb
+++ b/spec/percy/network_helpers_spec.rb
@@ -5,7 +5,7 @@ require 'percy/network_helpers'
 RSpec.describe Percy::NetworkHelpers do
   let(:server_port) { Percy::NetworkHelpers.random_open_port }
 
-  shared_context 'has a test HTTP server' do
+  shared_context 'with test HTTP server' do
     let(:server_url) { "http://localhost:#{server_port}" }
     let(:server) { WEBrick::HTTPServer.new(Port: server_port) }
 
@@ -49,7 +49,7 @@ RSpec.describe Percy::NetworkHelpers do
   end
 
   describe '#verify_healthcheck' do
-    include_context 'has a test HTTP server'
+    include_context 'with test HTTP server'
 
     it 'returns true if server is up and responds to healthcheck' do
       expect(Percy::NetworkHelpers.verify_healthcheck(url: server_url + '/healthz')).to eq(true)
@@ -62,7 +62,7 @@ RSpec.describe Percy::NetworkHelpers do
   end
   describe '#verify_http_server_up' do
     context 'when server is up' do
-      include_context 'has a test HTTP server'
+      include_context 'with test HTTP server'
 
       it 'returns true if server is up and responds to healthcheck' do
         result = Percy::NetworkHelpers.verify_http_server_up('localhost', port: server_port)

--- a/spec/percy/stats_spec.rb
+++ b/spec/percy/stats_spec.rb
@@ -3,6 +3,30 @@ require 'percy/stats'
 RSpec.describe Percy::Stats do
   let(:stats) { Percy::Stats.new }
 
+  context 'without env vars' do
+    it 'sets host and port from defaults' do
+      expect(stats.host).to eq('127.0.0.1')
+      expect(stats.port).to eq(8125)
+    end
+  end
+  context 'with env vars' do
+    before(:each) do
+      ENV['DATADOG_AGENT_HOST'] = 'localhost'
+      ENV['DATADOG_AGENT_PORT'] = '1000'
+    end
+    after(:each) do
+      ENV.delete('DATADOG_AGENT_HOST')
+      ENV.delete('DATADOG_AGENT_PORT')
+    end
+
+    it 'sets host and port from env vars' do
+      expect(stats.host).to eq('localhost')
+      expect(stats.port).to eq(1000)
+    end
+  end
+  it 'sets host based on DATADOG_AGENT_HOST' do
+    ENV['']
+  end
   it 'sets environment tag' do
     expect(stats.tags).to eq(['env:test'])
   end

--- a/spec/percy/stats_spec.rb
+++ b/spec/percy/stats_spec.rb
@@ -24,9 +24,6 @@ RSpec.describe Percy::Stats do
       expect(stats.port).to eq(1000)
     end
   end
-  it 'sets host based on DATADOG_AGENT_HOST' do
-    ENV['']
-  end
   it 'sets environment tag' do
     expect(stats.tags).to eq(['env:test'])
   end


### PR DESCRIPTION
- Upgrade dogstatsd from 1.6 to 3.1.
- Allow setting datadog agent host and port via `DATADOG_AGENT_HOST` and `DATADOG_AGENT_PORT` environment variables.
