### PR TITLE
Pin `dogstatsd-ruby` to 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: bundler
 rvm:
   - 2.4
-  - ruby-head
+  - 2.5
 before_install:
   - gem update --system
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: bundler
 rvm:
   - 2.4
-  - stable
+  - 2.5
 before_install:
   - gem update --system
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: bundler
 rvm:
   - 2.4
-  - 2.5
+  - ruby-stable
 before_install:
   - gem update --system
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: bundler
 rvm:
   - 2.4
-  - ruby-stable
+  - stable
 before_install:
   - gem update --system
   - gem update bundler

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '2.1.0'.freeze
+    VERSION = '2.1.1'.freeze
   end
 end

--- a/percy-common.gemspec
+++ b/percy-common.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
+  # Pinned as we rely on `time_since` which was taken out after this version.
   spec.add_dependency 'dogstatsd-ruby', '3.2.0'
+
   spec.add_dependency 'excon', '~> 0.57'
 
   spec.add_development_dependency 'bundler', '~> 1.15'

--- a/percy-common.gemspec
+++ b/percy-common.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'dogstatsd-ruby', '~> 3.1'
+  spec.add_dependency 'dogstatsd-ruby', '3.2.0'
   spec.add_dependency 'excon', '~> 0.57'
 
   spec.add_development_dependency 'bundler', '~> 1.15'


### PR DESCRIPTION
Because v3.3 breaks our tests as we rely on `time_since` and [that has been taken out](https://github.com/DataDog/dogstatsd-ruby/pull/70/files).

* bump the gem to v2.1.1
* avoid running our tests on `ruby-head`