### PR TITLE
Compare Time values in `time_since`

### DIFF
--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.0.0'.freeze
+    VERSION = '3.0.1'.freeze
   end
 end

--- a/lib/percy/stats.rb
+++ b/lib/percy/stats.rb
@@ -44,13 +44,29 @@ module Percy
       # Programmer mistake, so raise an error.
       raise 'no timing started' unless @_timing_start
 
-      time_since(stat, @_timing_start, options)
+      time_since_monotonic(stat, @_timing_start, options)
       @_timing_start = nil
       true
     end
 
-    def time_since(stat, start, opts = {})
+    # dogstatsd uses a monotonic (linearly increasing) clock to calculate time
+    # intervals, so this should be used where necessary. However, it's not
+    # possible to compare monotonic time values with fixed times, so both are
+    # available.
+    def time_since_monotonic(stat, start, opts = {})
+      unless start.instance_of? Float
+        raise ArgumentError, "start value must be Float"
+      end
+
       timing(stat, ((now.to_f - start.to_f) * 1000).round, opts)
+    end
+
+    def time_since(stat, start, opts = {})
+      unless start.instance_of? Time
+        raise ArgumentError, "start value must be Time"
+      end
+
+      timing(stat, ((Time.now.to_f - start.to_f) * 1000).round, opts)
     end
 
     private def now

--- a/lib/percy/stats.rb
+++ b/lib/percy/stats.rb
@@ -55,7 +55,7 @@ module Percy
     # available.
     def time_since_monotonic(stat, start, opts = {})
       unless start.instance_of? Float
-        raise ArgumentError, "start value must be Float"
+        raise ArgumentError, 'start value must be Float'
       end
 
       timing(stat, ((now.to_f - start.to_f) * 1000).round, opts)
@@ -63,7 +63,7 @@ module Percy
 
     def time_since(stat, start, opts = {})
       unless start.instance_of? Time
-        raise ArgumentError, "start value must be Time"
+        raise ArgumentError, 'start value must be Time'
       end
 
       timing(stat, ((Time.now.to_f - start.to_f) * 1000).round, opts)


### PR DESCRIPTION
This fixes a bug where passing a Time to `time_since` would compare it
to a monotonic clock value, with meaningless results.