### PR TITLE
Relax redis-rb version requirement

### DIFF
--- a/percy-common.gemspec
+++ b/percy-common.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'dogstatsd-ruby', '~> 4.4.0'
   spec.add_dependency 'excon', '~> 0.57'
-  spec.add_dependency 'redis', '~> 4.1.3'
+  spec.add_dependency 'redis', '>= 4.1.3', '< 5.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'


### PR DESCRIPTION
Allow applications that include this library to pin specific versions of redis-rb, as this gem wraps the library in a thin layer that’s unlikely to break due to minor changes in the upstream redis-rb library.