### PR TITLE
Allow explicit SSL parameters at initialization

### DIFF
--- a/lib/percy/redis_client.rb
+++ b/lib/percy/redis_client.rb
@@ -8,13 +8,8 @@ module Percy
     attr_reader :client
 
     def initialize(options = {})
-      @options = options
-      @client = ::Redis.new(
-        options.merge(
-          ssl: ssl_enabled?,
-          ssl_params: ssl_params,
-        ),
-      )
+      @options = ssl_options.merge(options)
+      @client = ::Redis.new(options)
     end
 
     private def ssl_enabled?
@@ -23,6 +18,13 @@ module Percy
 
     private def provided_url
       options.dig(:url)
+    end
+
+    private def ssl_options
+      {
+        ssl: ssl_enabled?,
+        ssl_params: ssl_params,
+      }
     end
 
     private def ssl_params

--- a/lib/percy/redis_client.rb
+++ b/lib/percy/redis_client.rb
@@ -17,7 +17,7 @@ module Percy
     end
 
     private def provided_url
-      options.dig(:url)
+      options&.dig(:url)
     end
 
     private def ssl_options

--- a/spec/percy/redis_client_spec.rb
+++ b/spec/percy/redis_client_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Percy::RedisClient do
     end
   end
 
-  context 'with a SSL-enabled redis URL' do
+  context 'with an SSL-enabled redis URL' do
     context 'with a mock redis server' do
       let(:redis_url) { "rediss://127.0.0.1:#{port}" }
       let(:options) { {url: redis_url} }


### PR DESCRIPTION
Allow specifying `ssl_params` directly, so the SSL certificate, private key and certificate authority file path can be provided explicitly at initialization, without relying on environment variables.