### PR TITLE
Add release script

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,16 +1,13 @@
 # Releasing
 
-1. `git pull origin master`
-1. Bump the version number in `lib/percy/common/version.rb`
-1. `git add lib/percy/common/version.rb`
-1. `git commit -m "version bump to X.X.X"`
-1. `git push origin master`
-1. `git tag vX.X.X`
-1. `git push --tags`
-1. `bundle exec rake build`
-1. `gem push pkg/percy-common-X.X.X.gem`
+1. Ensure you are on the expected branch (presumably `master`) and the current branch is up-to-date.
+1. Run `./release.sh`
 1. Visit [RubyGems.org](https://rubygems.org/gems/percy-common) and see the gem has been published
-1. Document the release on Github by first [creating a new release](https://github.com/percy/percy-common/releases/new)
+
+# Creating a Release on GitHub
+
+Finish the pre-started release opened by the script, or [create a new release](https://github.com/percy/percy-common/releases/new):
+
 1. Enter "vX.X.X" as the tag version. It should auto complete to say "Existing Tag"
 1. Enter "vX.X.X" as the release title
 1. Write a brief description as to what is included in this release. Linking to specific PRs is great.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")" || exit 1
+CURDIR="$(pwd)"
+
+PERCY_COMMON_VERSION="$(grep "VERSION" lib/percy/common/version.rb | awk -F "'" '{print $2}')"
+
+echo "Current percy-common version: $PERCY_COMMON_VERSION"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage $0 <version>"
+  exit 1
+fi
+
+rm "$CURDIR/"percy-common*.gem >/dev/null 2>&1 || true
+
+delete_existing_version() {
+  git tag -d "v$1" || true
+  git push origin ":v$1" || true
+  gem yank "percy-common$1.gem" || true
+}
+
+if [[ $1 == 'delete' ]]; then
+  delete_existing_version "$PERCY_COMMON_VERSION"
+else
+  CLEAN=$(
+    git diff-index --quiet HEAD --
+    echo $?
+  )
+  if [[ "$CLEAN" == "0" ]]; then
+    if [[ $1 == '--force' ]]; then
+      shift
+      if [[ -n $1 ]]; then
+        echo "Deleting version $1"
+        sleep 1
+        delete_existing_version "$1"
+      else
+        echo "Missing release version"
+        exit 1
+      fi
+    fi
+    VERSION=$1
+    echo "Releasing $VERSION"
+    sleep 1
+
+    sed -i "" -e "s/$PERCY_COMMON_VERSION/$VERSION/g" "lib/percy/common/version.rb"
+    git add "lib/percy/common/version.rb"
+    git commit -a -m "Release $VERSION" || true
+
+    git tag -a "v$VERSION" -m "$1" || true
+    git push origin "v$VERSION" || true
+
+    bundle exec rake build
+    gem push "$CURDIR/pkg/percy-common-$VERSION.gem"
+    open "https://github.com/percy/percy-common/releases/new?tag=v$VERSION&title=$VERSION"
+    rm "$CURDIR/pkg/percy-common-$VERSION.gem"
+  else
+    echo "Please commit your changes and try again"
+    exit 1
+  fi
+fi
+echo "Done"


### PR DESCRIPTION
This script changes the version number in the version.rb file, commits the changes, generates a new git tag, pushes the tag to github, pushes a new version of the gem to rubygems.org and opens the new release page on github.com. Finally, the temporary .gem file is removed from the pkg directory.

(This script was used to release v3.1.1.)