### PR TITLE
Fix Redis option parsing when using SSL-enabled connections

### DIFF
--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.2-rc.1'.freeze
+    VERSION = '3.1.2-rc.2'.freeze
   end
 end

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.0'.freeze
+    VERSION = '3.1.2-rc.1'.freeze
   end
 end

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.2-rc.3'.freeze
+    VERSION = '3.1.2'.freeze
   end
 end

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.2-rc.2'.freeze
+    VERSION = '3.1.2-rc.3'.freeze
   end
 end

--- a/lib/percy/redis_client.rb
+++ b/lib/percy/redis_client.rb
@@ -11,7 +11,7 @@ module Percy
 
     def initialize(given_options = {})
       @provided_options = given_options
-      @options = ssl_params.merge(given_options)
+      @options = ssl_options.merge(given_options)
       @client = ::Redis.new(options)
     end
 

--- a/lib/percy/redis_client.rb
+++ b/lib/percy/redis_client.rb
@@ -74,7 +74,6 @@ module Percy
 
     private def certificate_authority
       provided_certificate_authority ||
-        certificate_authority_from_env ||
         certificate_authority_from_path
     end
 
@@ -82,12 +81,8 @@ module Percy
       @provided_options&.dig(:ssl_params, :ca_file)
     end
 
-    private def certificate_authority_from_env
-      ENV['REDIS_SSL_CERTIFICATE_AUTHORITY']
-    end
-
     private def certificate_authority_from_path
-      File.read(fetch_key('REDIS_SSL_CERTIFICATE_AUTHORITY_PATH'))
+      fetch_key('REDIS_SSL_CERTIFICATE_AUTHORITY_PATH')
     end
 
     private def fetch_key(key)

--- a/release.sh
+++ b/release.sh
@@ -22,7 +22,10 @@ delete_existing_version() {
   gem yank "percy-common$1.gem" || true
 }
 
-if [[ $1 == 'delete' ]]; then
+if [[ $1 =~ ^.*delete$ ]]; then
+  shift
+  echo "Preparing to delete $1"
+  sleep 3
   delete_existing_version "$PERCY_COMMON_VERSION"
 else
   CLEAN=$(

--- a/release.sh
+++ b/release.sh
@@ -53,9 +53,9 @@ else
     git push origin "v$VERSION" || true
 
     bundle exec rake build
-    gem push "$CURDIR/pkg/percy-common-$VERSION.gem"
+    gem push "$CURDIR/pkg/percy-common-"*.gem
     open "https://github.com/percy/percy-common/releases/new?tag=v$VERSION&title=$VERSION"
-    rm "$CURDIR/pkg/percy-common-$VERSION.gem"
+    rm "$CURDIR/pkg/percy-common-"*.gem
   else
     echo "Please commit your changes and try again"
     exit 1

--- a/release.sh
+++ b/release.sh
@@ -19,7 +19,7 @@ rm "$CURDIR/"percy-common*.gem >/dev/null 2>&1 || true
 delete_existing_version() {
   git tag -d "v$1" || true
   git push origin ":v$1" || true
-  gem yank "percy-common$1.gem" || true
+  gem yank percy-common -v "$1" || true
 }
 
 if [[ $1 =~ ^.*delete$ ]]; then

--- a/release.sh
+++ b/release.sh
@@ -19,7 +19,9 @@ rm "$CURDIR/"percy-common*.gem >/dev/null 2>&1 || true
 delete_existing_version() {
   git tag -d "v$1" || true
   git push origin ":v$1" || true
-  gem yank percy-common -v "$1" || true
+  # Replace - with .pre. in version string for rubygems compatibility
+  GEM_VERSION=${1/-/.pre.}
+  gem yank percy-common -v "$GEM_VERSION" || true
 }
 
 if [[ $1 =~ ^.*delete$ ]]; then
@@ -35,17 +37,24 @@ else
   if [[ "$CLEAN" == "0" ]]; then
     if [[ $1 == '--force' ]]; then
       shift
-      if [[ -n $1 ]]; then
-        echo "Deleting version $1"
+      VERSION=$1
+      if [[ -n $VERSION ]]; then
+        echo "Deleting version $VERSION"
         sleep 1
-        delete_existing_version "$1"
+        delete_existing_version "$VERSION"
       else
         echo "Missing release version"
         exit 1
       fi
     fi
     VERSION=$1
-    echo "Releasing $VERSION"
+    # Replace - with .pre. in version string for rubygems compatibility
+    GEM_VERSION="${VERSION/-/.pre.}"
+    if [[ "$GEM_VERSION" == "$VERSION" ]]; then
+      echo "Releasing $VERSION"
+    else
+      echo "Releasing $VERSION as $GEM_VERSION"
+    fi
     sleep 1
 
     sed -i "" -e "s/$PERCY_COMMON_VERSION/$VERSION/g" "lib/percy/common/version.rb"
@@ -56,9 +65,9 @@ else
     git push origin "v$VERSION" || true
 
     bundle exec rake build
-    gem push "$CURDIR/pkg/percy-common-"*.gem
+    gem push "$CURDIR/pkg/percy-common-$GEM_VERSION.gem"
     open "https://github.com/percy/percy-common/releases/new?tag=v$VERSION&title=$VERSION"
-    rm "$CURDIR/pkg/percy-common-"*.gem
+    rm "$CURDIR/pkg/percy-common-$GEM_VERSION.gem"
   else
     echo "Please commit your changes and try again"
     exit 1


### PR DESCRIPTION
Prioritize configuration of Redis TLS keys in this order:

- Use the configuration value passed in using the options hash
- The value provided via an environment variable
- Read the file from the provided path (via the corresponding ENV value)