### PR TITLE
Update constant value drift in new dogstatsd-rb gem

### DIFF
--- a/lib/percy/stats.rb
+++ b/lib/percy/stats.rb
@@ -5,13 +5,13 @@ module Percy
   class Stats < ::Datadog::Statsd
     DEFAULT_HOST = ENV.fetch(
       'DATADOG_AGENT_HOST',
-      ::Datadog::Statsd::Connection::DEFAULT_HOST,
+      ::Datadog::Statsd::UDPConnection::DEFAULT_HOST,
     )
 
     DEFAULT_PORT = Integer(
       ENV.fetch(
         'DATADOG_AGENT_PORT',
-        ::Datadog::Statsd::Connection::DEFAULT_PORT,
+        ::Datadog::Statsd::UDPConnection::DEFAULT_PORT,
       ),
     )
 

--- a/spec/percy/stats_spec.rb
+++ b/spec/percy/stats_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Percy::Stats do
   let(:stats) { Percy::Stats.new }
 
   context 'without env vars' do
+    it 'assigns default constant values' do
+      expect(Percy::Stats::DEFAULT_HOST).to eq('127.0.0.1')
+      expect(Percy::Stats::DEFAULT_PORT).to eq(8125)
+    end
+
     it 'sets host and port from defaults' do
       expect(stats.connection.host).to eq '127.0.0.1'
       expect(stats.connection.port).to eq 8125


### PR DESCRIPTION
Bugfix to fix constant drift in dogstatsd-rb:

```ruby
       ::Datadog::Statsd::Connection::DEFAULT_HOST
```

has become:

```ruby
       ::Datadog::Statsd::UDPConnection::DEFAULT_HOST
```
