### PR TITLE
Suppress Errno::ESRCH after timeout

### DIFF
--- a/lib/percy/process_helpers.rb
+++ b/lib/percy/process_helpers.rb
@@ -17,7 +17,12 @@ module Percy
         # Status has already been collected, perhaps by a Process.detach thread.
         return false
       rescue Timeout::Error
-        Process.kill('KILL', pid)
+        begin
+          Process.kill('KILL', pid)
+        rescue Errno::ESRCH
+          # If the process has already ended, suppress any additional errors
+          return false
+        end
         # Collect status so it doesn't stick around as zombie process.
         Process.wait(pid, Process::WNOHANG)
       end


### PR DESCRIPTION
Sometimes we see [this error](https://sentry.io/organizations/percy/issues/1498361869/?project=1415874) in production and occasionally in CI. This will suppress any addtional errors in cleaning up a missing process.