### PR TITLE
[PPLT-1530] Adding header support rproxy

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents: &agents
-  os: 'linux'
+  os: 'linux_small'
 
 command: &command
   - make test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ RSpec/DescribeClass:
   Exclude:
     - spec/percy/logger_spec.rb
 
+# TODO: disable new cops
 AllCops:
+  TargetRubyVersion: 2.6
   Exclude:
     - spec/support/redis_mock.rb

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.7-beta'.freeze
+    VERSION = '3.1.8'.freeze
   end
 end

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.6'.freeze
+    VERSION = '3.1.7-beta'.freeze
   end
 end

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.6'.freeze
+    VERSION = '3.1.7'.freeze
   end
 end

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.7'.freeze
+    VERSION = '3.1.6'.freeze
   end
 end

--- a/lib/percy/network_helpers.rb
+++ b/lib/percy/network_helpers.rb
@@ -29,7 +29,7 @@ module Percy
     end
 
     def self.verify_healthcheck(url:, expected_body: 'ok', retry_wait_seconds: 0.5, proxy: nil,
-      headers: nil)
+      headers: {})
       10.times do
         begin
           response = Excon.get(url, proxy: proxy, headers: headers)
@@ -42,7 +42,7 @@ module Percy
     end
 
     def self.verify_http_server_up(hostname, port: nil,
-      path: nil, retry_wait_seconds: 0.25, proxy: nil, headers: nil)
+      path: nil, retry_wait_seconds: 0.25, proxy: nil, headers: {})
       10.times do
         begin
           url = "http://#{hostname}#{port.nil? ? '' : ':' + port.to_s}#{path || ''}"

--- a/lib/percy/network_helpers.rb
+++ b/lib/percy/network_helpers.rb
@@ -28,10 +28,11 @@ module Percy
       end
     end
 
-    def self.verify_healthcheck(url:, expected_body: 'ok', retry_wait_seconds: 0.5, proxy: nil)
+    def self.verify_healthcheck(url:, expected_body: 'ok', retry_wait_seconds: 0.5, proxy: nil,
+      headers: nil)
       10.times do
         begin
-          response = Excon.get(url, proxy: proxy)
+          response = Excon.get(url, proxy: proxy, headers: headers)
           return true if response.body == expected_body
         rescue Excon::Error::Socket, Excon::Error::Timeout
           sleep retry_wait_seconds
@@ -41,11 +42,11 @@ module Percy
     end
 
     def self.verify_http_server_up(hostname, port: nil,
-      path: nil, retry_wait_seconds: 0.25, proxy: nil)
+      path: nil, retry_wait_seconds: 0.25, proxy: nil, headers: nil)
       10.times do
         begin
           url = "http://#{hostname}#{port.nil? ? '' : ':' + port.to_s}#{path || ''}"
-          Excon.get(url, proxy: proxy)
+          Excon.get(url, proxy: proxy, headers: headers)
           return true
         rescue Excon::Error::Socket, Excon::Error::Timeout
           sleep retry_wait_seconds

--- a/percy-common.gemspec
+++ b/percy-common.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(/^(test|spec|features)\//)
   end
+
+  spec.required_ruby_version = '>= 2.6'
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dogstatsd-ruby', '>= 4.4', '< 4.9'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'pathname'
 
 Dir[
   Pathname.new(__dir__).join('support', '**', '*.rb'),
-].each { |f| require f }
+].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Adding headers support to the excon.get calls of verify_healthcheck and verify_http_server_up so that we can properly support rproxy calls.