### PR TITLE
Added params support in Percy::NetworkHelpers::random_open_port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # setup default base image
-BASE_IMAGE ?= ruby:3.0.0-alpine
+BASE_IMAGE ?= ruby:2.6-alpine
 
 build:
 	docker-compose build --build-arg BASE_IMAGE="$(BASE_IMAGE)"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # setup default base image
-BASE_IMAGE ?= ruby:2.6-alpine
+BASE_IMAGE ?= ruby:3.0.0-alpine
 
 build:
 	docker-compose build --build-arg BASE_IMAGE="$(BASE_IMAGE)"

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.8'.freeze
+    VERSION = '3.1.9'.freeze
   end
 end

--- a/lib/percy/network_helpers.rb
+++ b/lib/percy/network_helpers.rb
@@ -10,9 +10,9 @@ module Percy
     class ServerDown < RuntimeError; end
     class OpenPortNotFound < RuntimeError; end
 
-    def self.random_open_port
+    def self.random_open_port(min_port: MIN_PORT, max_port: MAX_PORT)
       MAX_PORT_ATTEMPTS.times do
-        port = rand(MIN_PORT..MAX_PORT)
+        port = rand(min_port..max_port)
         return port if port_open? port
       end
 

--- a/spec/percy/network_helpers_spec.rb
+++ b/spec/percy/network_helpers_spec.rb
@@ -22,9 +22,16 @@ RSpec.describe Percy::NetworkHelpers do
   end
 
   describe '#random_open_port' do
+    let(:custom_min_port) { 1026 }
+    let(:custom_max_port) { 1028 }
     it 'returns a random open port in the desired range' do
       expect(Percy::NetworkHelpers.random_open_port).to be >= described_class::MIN_PORT
       expect(Percy::NetworkHelpers.random_open_port).to be <= described_class::MAX_PORT
+    end
+
+    it 'return a random open port in the user given range' do
+      expect(Percy::NetworkHelpers.random_open_port(min_port: custom_min_port, max_port: custom_max_port)).to be >= custom_min_port
+      expect(Percy::NetworkHelpers.random_open_port(min_port: custom_min_port, max_port: custom_max_port)).to be <= custom_max_port
     end
 
     it 'raises an error when an open port is not found' do


### PR DESCRIPTION
- If you want to get random port in some desired range.

Changes: 
- Percy::NetworkHelpers::random_open_port
- Updated ruby BASE IMAGE to >= 3.0.0, since `RUN gem install bundler` was throwing issue
```
[app 3/6] RUN gem install bundler:                                                                                                                                                     
43.29 ERROR:  Error installing bundler:                                                                                                                                                   
43.29   The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
43.29   bundler requires Ruby version >= 3.0.0. The current ruby version is 2.6.10.210.
------
failed to solve: process "/bin/sh -c gem install bundler" did not complete successfully: exit code: 1
```