### PR TITLE
Bump version to 3.2.0.alpha.1 and update excon dependency to allow any version >= 0.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or, for a Ruby library, add this to your gemspec:
 spec.add_development_dependency 'percy-common'
 ```
 
-And then run:
+And then run
 
 ```bash
 $ bundle install

--- a/lib/percy/common/version.rb
+++ b/lib/percy/common/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Common
-    VERSION = '3.1.9'.freeze
+    VERSION = '3.2.0.alpha.1'.freeze
   end
 end

--- a/percy-common.gemspec
+++ b/percy-common.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dogstatsd-ruby', '>= 4.4', '< 4.9'
-  spec.add_dependency 'excon', '~> 0.57'
+  spec.add_dependency 'excon', '>= 0.57'
   spec.add_dependency 'redis', '>= 4.1.3', '< 5.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
Bump version to 3.2.0.alpha.1 and update excon dependency to allow any version >= 0.57