### PR TITLE
security: pin Docker base images by digest + add .dockerignore (PER-8633)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,18 +12,18 @@ steps:
 
   - label: ':rspec: Test Ruby 2.6'
     env:
-      BASE_IMAGE: 'ruby:2.6-alpine'
+      BASE_IMAGE: 'ruby:2.6-alpine@sha256:382ce92de42ef027bf1bfe382c3f3c3878042c41c07da8b8aa41855db0894762'
     agents: *agents
     command: *command
 
   - label: ':rspec: Test Ruby 2.7'
     env:
-      BASE_IMAGE: 'ruby:2.7-alpine'
+      BASE_IMAGE: 'ruby:2.7-alpine@sha256:371668748735a808d1fd1c506878e09f40cb542ffc758cfa7eb124f90827e8d9'
     agents: *agents
     command: *command
 
   - label: ':rspec: Test Ruby 3.0'
     env:
-      BASE_IMAGE: 'ruby:3.0-alpine'
+      BASE_IMAGE: 'ruby:3.0-alpine@sha256:a59120aca45394ee979248e886672acaac91f175daf52cb91deb43075b076bd1'
     agents: *agents
     command: *command

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep non-runtime files out of the build context so they cannot be copied into
+# image layers by `ADD . /app/src`. NOTE: spec/ is intentionally NOT excluded —
+# `make test` runs `bundle exec rspec` inside the container and needs it
+# (including the SSL fixtures under spec/support/ssl/).
+.git/
+.github/
+.buildkite/
+.gitignore
+.rubocop.yml
+README.md
+*.env
+.env.*

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-# setup default base image
-BASE_IMAGE ?= ruby:2.6-alpine
+# setup default base image (digest-pinned so the default build cannot be
+# silently swapped via a mutable tag — see PER-8633)
+BASE_IMAGE ?= ruby:2.6-alpine@sha256:382ce92de42ef027bf1bfe382c3f3c3878042c41c07da8b8aa41855db0894762
 
 build:
 	docker-compose build --build-arg BASE_IMAGE="$(BASE_IMAGE)"


### PR DESCRIPTION
## Summary
Breaks the **High**-severity supply-chain chain [PER-8633](https://browserstack.atlassian.net/browse/PER-8633) (C-001, combined CVSS 9.1): an unpinned `BASE_IMAGE` lets an attacker who can influence the pipeline substitute a malicious image, gaining build-time RCE; `ADD . /app/src` then copies the committed RSA test keys and full source into an attacker-controlled layer for exfiltration.

## Changes
- **`.buildkite/pipeline.yml`** — pinned all three test base images (`ruby:2.6/2.7/3.0-alpine`) to immutable `@sha256` digests. The legitimate CI path can no longer have a mutable tag swapped for a tampered image. (Multi-version testing preserved.)
- **`Makefile`** — digest-pinned the default `BASE_IMAGE` used by local `make build`.
- **`.dockerignore`** (new) — keeps `.git/`, `.github/`, `.buildkite/` and env files out of the build context.
  - `spec/` is **intentionally kept** in the context: `make test` runs `bundle exec rspec` *inside* the container, so the SSL fixtures under `spec/support/ssl/` must be present. Excluding it would silently break the test suite.

## Out of scope (flagged on the ticket as follow-ups)
- Commit `Gemfile.lock` + run `bundle install --frozen` for reproducible resolution (touches dependency resolution; better as its own change).
- Rotate the committed test RSA keys (`spec/support/ssl/*.key`) and confirm `trusted-ca.crt` is not present in any prod/staging trust store — an **ops action**, not a code change.

## Verification
- `pipeline.yml` parses cleanly; digests resolved live from Docker Hub registry for each `ruby:*-alpine` tag.

Closes PER-8633 (chain entry pinned; data-exfil follow-ups flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8633]: https://browserstack.atlassian.net/browse/PER-8633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ