### PR TITLE
security: remove REDIS_SSL_PRIVATE_KEY env var path (PER-8500)

### DIFF
--- a/lib/percy/redis_client.rb
+++ b/lib/percy/redis_client.rb
@@ -56,16 +56,11 @@ module Percy
 
     private def private_key
       provided_private_key ||
-        private_key_from_env ||
         private_key_from_path
     end
 
     private def provided_private_key
       @provided_options&.dig(:ssl_params, :key)
-    end
-
-    private def private_key_from_env
-      ENV['REDIS_SSL_PRIVATE_KEY']
     end
 
     private def private_key_from_path

--- a/spec/percy/redis_client_spec.rb
+++ b/spec/percy/redis_client_spec.rb
@@ -108,6 +108,36 @@ RSpec.describe Percy::RedisClient do
         File.expand_path('../support/ssl', __dir__)
       end
     end
+
+    context 'without REDIS_SSL_PRIVATE_KEY_PATH or an explicit key' do
+      let(:options) { {url: 'rediss://127.0.0.1:6379'} }
+      let(:cert_path) { File.expand_path('../support/ssl', __dir__) }
+
+      it 'raises InvalidConfiguration instead of silently falling back to an env key' do
+        env_keys = %w[
+          REDIS_SSL_PRIVATE_KEY REDIS_SSL_PRIVATE_KEY_PATH
+          REDIS_SSL_CERTIFICATE_AUTHORITY_PATH
+          REDIS_SSL_CLIENT_CERTIFICATE REDIS_SSL_CLIENT_CERTIFICATE_PATH
+        ]
+        original = env_keys.each_with_object({}) { |k, h| h[k] = ENV[k] }
+        env_keys.each { |k| ENV.delete(k) }
+
+        # Provide CA + client cert paths so the request reaches the key
+        # branch; the only thing we want to test is that setting the
+        # removed REDIS_SSL_PRIVATE_KEY env var does NOT satisfy the
+        # private-key requirement.
+        ENV['REDIS_SSL_CERTIFICATE_AUTHORITY_PATH'] = File.join(cert_path, 'trusted-ca.crt')
+        ENV['REDIS_SSL_CLIENT_CERTIFICATE_PATH'] = File.join(cert_path, 'trusted-cert.crt')
+        ENV['REDIS_SSL_PRIVATE_KEY'] = 'placeholder-this-must-not-be-honoured'
+
+        expect { Percy::RedisClient.new(options) }.to raise_error(
+          Percy::RedisClient::InvalidConfiguration,
+          /REDIS_SSL_PRIVATE_KEY_PATH is not defined/,
+        )
+      ensure
+        env_keys.each { |k| ENV[k] = original[k] }
+      end
+    end
   end
 
   context 'with explicit SSL redis parameters' do


### PR DESCRIPTION
## Summary

[PER-8500](https://browserstack.atlassian.net/browse/PER-8500) — \`Percy::RedisClient\` previously accepted the raw RSA private key via \`REDIS_SSL_PRIVATE_KEY\`. Anything that captures the process environment (\`/proc\`, Sentry, Honeybadger, Datadog APM env-capture, pod specs, audit logs) could lift the key in plaintext, enabling Redis-client impersonation in mTLS or decryption of captured sessions. CVSS 5.5, CWE-321.

This PR drops the \`private_key_from_env\` code path entirely. Key material must now be supplied either:

1. explicitly via \`ssl_params[:key]\` when constructing the client, or
2. by pointing \`REDIS_SSL_PRIVATE_KEY_PATH\` at a file with restrictive (e.g. 0400) permissions — on k8s/ECS, a volume-backed secret.

## Why this is split from the other PER-* fixes

This is a **behaviour-changing breaking change**: any downstream service currently setting \`REDIS_SSL_PRIVATE_KEY\` will start raising \`InvalidConfiguration: REDIS_SSL_PRIVATE_KEY_PATH is not defined\` the moment it picks up the new percy-common. Separating it from the other PER tickets so it can be reviewed and rolled out on its own cadence.

**Action item for reviewers:** before merging, please confirm whether any production service in the org sets \`REDIS_SSL_PRIVATE_KEY\` (rg / grep across the consuming repos). If so, those services need to be cut over to \`REDIS_SSL_PRIVATE_KEY_PATH\` (or pass the key directly via \`ssl_params\`) in the same release that bumps percy-common.

The cert-side counterpart \`REDIS_SSL_CLIENT_CERTIFICATE\` (env var) is left in place — it carries no private-key material — and can be tackled separately if we want to standardise on file-only inputs.

## Test plan

- [x] \`bundle exec rubocop lib/percy/redis_client.rb\` (clean)
- [ ] \`bundle exec rspec spec/percy/redis_client_spec.rb\` — the two SSL-mock specs fail on master today on Ruby 3.2+ because the committed test CA is SHA-1 signed (\`ca md too weak\`). That regression is unrelated to this change and is fixed by [PER-8502 / PR #1](https://browserstack.atlassian.net/browse/PER-8502). After that PR lands, CI on this branch should be green.
- [ ] Confirm no production service still reads \`REDIS_SSL_PRIVATE_KEY\`

[PER-8500]: https://browserstack.atlassian.net/browse/PER-8500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ