### PR TITLE
[TEST – do not merge] docs-only CI skip verification

### DIFF
--- a/CI_DOCS_ONLY_TEST.md
+++ b/CI_DOCS_ONLY_TEST.md
@@ -1,0 +1,6 @@
+# CI docs-only skip — test artifact
+
+This file produces a documentation-only diff (vs the feature branch) so we can
+confirm the `.buildkite` bootstrap skips CI for docs-only pull requests.
+
+**Do not merge.** Delete this file and close the PR once the skip is confirmed.


### PR DESCRIPTION
## Purpose

Throwaway PR to verify the **docs-only skip path** of the bootstrap on real Buildkite.

- **Base:** `ci/skip-ci-for-docs-only-prs` (NOT master), so the only diff vs base is one `.md` file while the bootstrap is present on both sides.
- **Expected:** the build runs only the `:mag: Resolve CI scope` step, prints "Docs-only PR — skipping CI", and goes green — no test steps.

**Delete the file and close this PR once verified.**
