### PR TITLE
[TEST – do not merge] docs-only CI skip verification

### DIFF
--- a/.buildkite/pipeline.steps.yml
+++ b/.buildkite/pipeline.steps.yml
@@ -1,0 +1,29 @@
+agents: &agents
+  os: 'linux_small'
+
+command: &command
+  - make test
+
+steps:
+  - label: ':rubocop: Lint'
+    agents: *agents
+    command:
+      - make lint
+
+  - label: ':rspec: Test Ruby 2.6'
+    env:
+      BASE_IMAGE: 'ruby:2.6-alpine'
+    agents: *agents
+    command: *command
+
+  - label: ':rspec: Test Ruby 2.7'
+    env:
+      BASE_IMAGE: 'ruby:2.7-alpine'
+    agents: *agents
+    command: *command
+
+  - label: ':rspec: Test Ruby 3.0'
+    env:
+      BASE_IMAGE: 'ruby:3.0-alpine'
+    agents: *agents
+    command: *command

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,29 +1,30 @@
-agents: &agents
-  os: 'linux_small'
-
-command: &command
-  - make test
-
+# Bootstrap pipeline (uploaded by Buildkite for every build in this repo).
+#
+# It decides whether to run the full CI pipeline, which now lives in
+# .buildkite/pipeline.steps.yml:
+#
+#   * Any non-PR build (branch / merge / tag, incl. master and deploy branches)
+#     -> ALWAYS run the full pipeline. Deploys are never gated on docs detection.
+#   * pull_request builds that change ONLY documentation (*.md, *.txt, README*,
+#     LICENSE, docs/**)  -> upload nothing, so the build passes with just this
+#     step and no compute is spent.
+#   * everything else (any non-docs file changed, or the diff can't be computed)
+#     -> run the full pipeline (fail-safe).
 steps:
-  - label: ':rubocop: Lint'
-    agents: *agents
-    command:
-      - make lint
-
-  - label: ':rspec: Test Ruby 2.6'
-    env:
-      BASE_IMAGE: 'ruby:2.6-alpine'
-    agents: *agents
-    command: *command
-
-  - label: ':rspec: Test Ruby 2.7'
-    env:
-      BASE_IMAGE: 'ruby:2.7-alpine'
-    agents: *agents
-    command: *command
-
-  - label: ':rspec: Test Ruby 3.0'
-    env:
-      BASE_IMAGE: 'ruby:3.0-alpine'
-    agents: *agents
-    command: *command
+  - label: ":mag: Resolve CI scope (docs-only skip)"
+    key: "bootstrap"
+    agents:
+      os: "linux_super_small"
+    command: "bash .buildkite/scripts/upload-pipeline.sh"
+    timeout_in_minutes: 5
+    # Mirror the retry policy used by the full pipeline so a lost agent (-1) /
+    # Docker daemon error (125) / preemptible-VM shutdown (255) re-runs the
+    # bootstrap instead of failing the whole build.
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 125 # Error response from Docker daemon
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown often due to preemptible VMs
+          limit: 2

--- a/.buildkite/scripts/upload-pipeline.sh
+++ b/.buildkite/scripts/upload-pipeline.sh
@@ -10,15 +10,19 @@ upload_full() {
   exit $?
 }
 
-# Only pull-request builds are eligible for the docs-only skip. Every other build
-# (branch / merge / tag, including master and any deploy branch) runs full CI.
-if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
-  upload_full
-fi
+DEFAULT="${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-master}"
 
-BASE="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+# Always run full CI on the default branch and known deploy branches. The
+# docs-only skip only ever applies to feature branches, so this works for both
+# branch builds and PR builds — no dependency on PR context.
+case "${BUILDKITE_BRANCH:-}" in
+  "$DEFAULT"|master|percy_pre_prod|pre_master) upload_full ;;
+esac
 
-# CI clones can be shallow; fetch the PR base so we can diff against it.
+# Diff against the PR base when known, otherwise the default branch.
+BASE="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-$DEFAULT}"
+
+# CI clones can be shallow; fetch the base so we can diff against it.
 git fetch --no-tags origin "+refs/heads/${BASE}:refs/remotes/origin/${BASE}" >/dev/null 2>&1 || true
 
 FILES="$(git diff --name-only "origin/${BASE}...HEAD" 2>/dev/null || true)"
@@ -37,5 +41,5 @@ if printf '%s\n' "$FILES" | grep -qvE '(\.md|\.txt)$|(^|/)README[^/]*$|(^|/)LICE
   upload_full
 fi
 
-echo "+++ Docs-only PR — skipping CI"
+echo "+++ Docs-only change — skipping CI"
 buildkite-agent annotate "Docs-only change — full CI skipped." --style "info" --context "docs-only" || true

--- a/.buildkite/scripts/upload-pipeline.sh
+++ b/.buildkite/scripts/upload-pipeline.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Decide whether to upload the full pipeline. See .buildkite/pipeline.yml.
+set -uo pipefail
+
+FULL=".buildkite/pipeline.steps.yml"
+
+upload_full() {
+  echo "+++ Uploading full pipeline"
+  buildkite-agent pipeline upload "$FULL"
+  exit $?
+}
+
+# Only pull-request builds are eligible for the docs-only skip. Every other build
+# (branch / merge / tag, including master and any deploy branch) runs full CI.
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  upload_full
+fi
+
+BASE="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+
+# CI clones can be shallow; fetch the PR base so we can diff against it.
+git fetch --no-tags origin "+refs/heads/${BASE}:refs/remotes/origin/${BASE}" >/dev/null 2>&1 || true
+
+FILES="$(git diff --name-only "origin/${BASE}...HEAD" 2>/dev/null || true)"
+echo "--- Changed files vs origin/${BASE}"
+printf '%s\n' "$FILES"
+
+# Fail-safe: if the diff is empty or couldn't be computed, run the full pipeline.
+if [[ -z "${FILES//[[:space:]]/}" ]]; then
+  echo "No diff computed; running full pipeline."
+  upload_full
+fi
+
+# Docs allowlist: *.md, *.txt, README*, LICENSE, docs/**. If ANY changed file
+# falls outside it, run the full pipeline; otherwise skip CI (upload nothing).
+if printf '%s\n' "$FILES" | grep -qvE '(\.md|\.txt)$|(^|/)README[^/]*$|(^|/)LICENSE$|^docs/'; then
+  upload_full
+fi
+
+echo "+++ Docs-only PR — skipping CI"
+buildkite-agent annotate "Docs-only change — full CI skipped." --style "info" --context "docs-only" || true

--- a/CI_DOCS_ONLY_TEST.md
+++ b/CI_DOCS_ONLY_TEST.md
@@ -1,0 +1,4 @@
+# CI docs-only skip — verification
+
+Docs-only diff vs the feature branch to confirm the bootstrap skips CI.
+**Do not merge** — delete and close once the skip is confirmed.


### PR DESCRIPTION
Docs-only test (single `.md`) stacked on `ci/skip-ci-for-docs-only-prs`.
**Expected:** build runs only the `:mag: Resolve CI scope` step and goes green ("Docs-only change — skipping CI"). Do not merge.
