### PR TITLE
[TEST – do not merge] docs-only CI skip (live off master)

### DIFF
--- a/DOCS_ONLY_CI_TEST.md
+++ b/DOCS_ONLY_CI_TEST.md
@@ -1,0 +1,5 @@
+# Docs-only CI skip — live verification
+
+Real docs-only PR off master to confirm the bootstrap skips CI naturally
+(normal push build, clean diff vs master). **Do not merge** — delete + close
+once the skip is confirmed.


### PR DESCRIPTION
Real **docs-only** PR off `master` (single `.md`) to verify the merged bootstrap skips CI naturally as a normal push build.

**Expected:** build runs only the `:mag: Resolve CI scope` step and goes green ("Docs-only change — skipping CI") — no test steps. **Do not merge.**
